### PR TITLE
.github/ISSUE_TEMPLATE: various formatting and typo fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: 'Report a problem in existing functionality, including documentation and infrastructure.'
+about: Report a problem in existing functionality, including documentation and infrastructure.
 title: ''
 labels: 'P: default, T: bug, W: todo'
 assignees: ''
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Affected component(s) or functionality**
-_The component or functionality of Trenchboot that is not working as expected._
+_The component or functionality of TrenchBoot that is not working as expected._
 
 **Brief summary**
 _A clear and concise summary of the bug._
@@ -39,7 +39,9 @@ _Add any other context about the problem here._
 _If applicable, any solutions or workarounds you've already tried._
 
 **Relevant documentation you've consulted**
-_A list of links to any relavant documentation you have consulted._
+_A list of links to any relevant documentation you have consulted._
 
 **Related, non-duplicate issues**
-_A list of links to other bug reports, feature requests, or tasks in the trenchboot-issues tracker (or "none" if you didn't find any). Do not describe any other unreported bugs, features, or tasks here._
+_A list of links to other bug reports, feature requests, or tasks in the
+trenchboot-issues tracker (or "none" if you didn't find any). Do not describe
+any other unreported bugs, features, or tasks here._

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -8,22 +8,28 @@ assignees: ''
 ---
 
 **The problem you're addressing (if any)**
-_A clear and concise description of the problem, if any, that this enhancement is intended to address._
+_A clear and concise description of the problem, if any, that this enhancement
+is intended to address._
 
 **Describe the solution you'd like**
-_If you have something in mind, a clear and concise description of what you want to happen. If you don't have something in mind, indicate as much._
+_If you have something in mind, a clear and concise description of what you
+want to happen. If you don't have something in mind, indicate as much._
 
 **Where is the value to a user, and who might that user be?**
-_Which users is this most likely to benefit? What user needs does this address? How might a user summarize this change or new thing?_
+_Which users is this most likely to benefit? What user needs does this address?
+How might a user summarize this change or new thing?_
 
 **Describe alternatives you've considered**
-_A clear and concise description of any alternative solutions or features you've considered._
+_A clear and concise description of any alternative solutions or features
+you've considered._
 
 **Additional context**
 _Add any other context or screenshots about the feature request here._
 
 **Relevant documentation you've consulted**
-_A list of links to any relavant documentation you have consulted._
+_A list of links to any relevant documentation you have consulted._
 
-**Related, [non-duplicate] issues**
-_A list of links to other bug reports, feature requests, or tasks in the trenchboot-issues tracker. Do not describe any other unreported bugs, features, or tasks here._
+**Related, non-duplicate issues**
+_A list of links to other bug reports, feature requests, or tasks in the
+trenchboot-issues tracker. Do not describe any other unreported bugs, features,
+or tasks here._

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -8,7 +8,8 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-_A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]_
+_A clear and concise description of what the problem is. Ex. I'm always
+frustrated when [...]_
 
 **Is your feature request related to a new idea or technology that
 would benefit the project? Please describe.**
@@ -19,10 +20,11 @@ benefit the project._
 _A clear and concise description of what you want to happen._
 
 **Describe alternatives you've considered**
-_A clear and concise description of any alternative solutions or features you've considered._
+_A clear and concise description of any alternative solutions or features
+you've considered._
 
 **Additional context**
 _Add any other context or screenshots about the feature request here._
 
 **Relevant documentation you've consulted**
-_A list of links to any relavant documentation you have consulted._
+_A list of links to any relevant documentation you have consulted._

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -8,7 +8,8 @@ assignees: ''
 ---
 
 **Affected component(s) or functionality (if applicable)**
-_If applicable, the component or functionality of Trenchboot that this task concerns._
+_If applicable, the component or functionality of TrenchBoot that this task
+concerns._
 
 **Brief summary**
 _A clear and concise summary of the task that should be done._
@@ -20,7 +21,9 @@ _The version of the component or feature if available, otherwise NA._
 _Add any other context about the problem here._
 
 **Relevant documentation you've consulted**
-_A list of links to any relavant documentation you have consulted._
+_A list of links to any relevant documentation you have consulted._
 
 **Related, non-duplicate issues**
-_A list of links to other bug reports, feature requests, or tasks in the trenchboot-issues tracker. Do not describe any other unreported bugs, features, or tasks here._
+_A list of links to other bug reports, feature requests, or tasks in the
+trenchboot-issues tracker. Do not describe any other unreported bugs, features,
+or tasks here._


### PR DESCRIPTION
This patch wrap at 80 characters to improve readability and review
process. It fixes typo and make templates more consistent by using the
same wording.

Signed-off-by: Piotr Król <piotr.krol@3mdeb.com>